### PR TITLE
Add a benchmark to test the performance of generating the most common values on different locales

### DIFF
--- a/src/main/java/net/datafaker/benchmark/locale/LocalePerformanceBenchmark.java
+++ b/src/main/java/net/datafaker/benchmark/locale/LocalePerformanceBenchmark.java
@@ -1,0 +1,61 @@
+package net.datafaker.benchmark.locale;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This benchmark tests the performance of the generation of most common values on different locales.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
+public class LocalePerformanceBenchmark {
+    private static final net.datafaker.Faker DATA_FAKER_ENGLISH = new net.datafaker.Faker(Locale.ENGLISH);
+    private static final net.datafaker.Faker DATA_FAKER_UK = new net.datafaker.Faker(Locale.UK);
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(LocalePerformanceBenchmark.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void en_fullname(Blackhole blackhole) {
+        blackhole.consume(DATA_FAKER_ENGLISH.name().name());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void en_gb_fullname(Blackhole blackhole) {
+        blackhole.consume(DATA_FAKER_UK.name().name());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void en_streetAddress(Blackhole blackhole) {
+        blackhole.consume(DATA_FAKER_ENGLISH.address().streetAddress());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void en_gb_streetAddress(Blackhole blackhole) {
+        blackhole.consume(DATA_FAKER_UK.address().streetAddress());
+    }
+}


### PR DESCRIPTION
This benchmark related to the PR https://github.com/datafaker-net/datafaker/pull/1286

Before changes:
```
Benchmark                                        Mode  Cnt     Score     Error   Units
LocalePerformanceBenchmark.en_fullname          thrpt   10  2700.254 ± 161.029  ops/ms
LocalePerformanceBenchmark.en_gb_fullname       thrpt   10    12.079 ±   1.952  ops/ms
LocalePerformanceBenchmark.en_gb_streetAddress  thrpt   10    11.230 ±   1.599  ops/ms
LocalePerformanceBenchmark.en_streetAddress     thrpt   10  2045.465 ±  70.737  ops/ms
```

After changes:
```
Benchmark                                        Mode  Cnt     Score     Error   Units
LocalePerformanceBenchmark.en_fullname          thrpt   10  2645.880 ± 216.553  ops/ms
LocalePerformanceBenchmark.en_gb_fullname       thrpt   10    38.643 ±   3.966  ops/ms
LocalePerformanceBenchmark.en_gb_streetAddress  thrpt   10    51.417 ±  11.488  ops/ms
LocalePerformanceBenchmark.en_streetAddress     thrpt   10  1909.792 ± 213.204  ops/ms
```